### PR TITLE
README.adoc: Update links for CI Build Status

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,8 +2,8 @@
 ifdef::env-github,env-browser[:relfileprefix: docs/]
 ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 
-https://travis-ci.org/se-edu/addressbook-level4[image:https://travis-ci.org/se-edu/addressbook-level4.svg?branch=master[Build Status]]
-https://ci.appveyor.com/project/damithc/addressbook-level4[image:https://ci.appveyor.com/api/projects/status/3boko2x2vr5cc3w2?svg=true[Build status]]
+https://travis-ci.org/CS2103AUG2017-T09-B4/main[image:https://travis-ci.org/CS2103AUG2017-T09-B4/main.svg?branch=master[Build Status]]
+https://ci.appveyor.com/project/limyongsong/main[image:https://ci.appveyor.com/api/projects/status/3boko2x2vr5cc3w2?svg=true[Build status]]
 https://coveralls.io/github/se-edu/addressbook-level4?branch=master[image:https://coveralls.io/repos/github/se-edu/addressbook-level4/badge.svg?branch=master[Coverage Status]]
 https://www.codacy.com/app/damith/addressbook-level4?utm_source=github.com&utm_medium=referral&utm_content=se-edu/addressbook-level4&utm_campaign=Badge_Grade[image:https://api.codacy.com/project/badge/Grade/fc0b7775cf7f4fdeaf08776f3d8e364a[Codacy Badge]]
 

--- a/README.adoc
+++ b/README.adoc
@@ -3,7 +3,7 @@ ifdef::env-github,env-browser[:relfileprefix: docs/]
 ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 
 https://travis-ci.org/CS2103AUG2017-T09-B4/main[image:https://travis-ci.org/CS2103AUG2017-T09-B4/main.svg?branch=master[Build Status]]
-https://ci.appveyor.com/project/limyongsong/main[image:https://ci.appveyor.com/api/projects/status/3boko2x2vr5cc3w2?svg=true[Build status]]
+https://ci.appveyor.com/project/limyongsong/main/branch/master[image:https://ci.appveyor.com/api/projects/status/u64s0m5nsfgfprie/branch/master?svg=true[Build status]]
 https://coveralls.io/github/se-edu/addressbook-level4?branch=master[image:https://coveralls.io/repos/github/se-edu/addressbook-level4/badge.svg?branch=master[Coverage Status]]
 https://www.codacy.com/app/damith/addressbook-level4?utm_source=github.com&utm_medium=referral&utm_content=se-edu/addressbook-level4&utm_campaign=Badge_Grade[image:https://api.codacy.com/project/badge/Grade/fc0b7775cf7f4fdeaf08776f3d8e364a[Codacy Badge]]
 


### PR DESCRIPTION
README.adoc: Update links for Build Status from Travis Continuous Integration (CI) and AppVeyor CI after doing "Developer Guide 1.4.3. Setting up CI"
----
Followed https://github.com/limyongsong/main/blob/master/docs/DeveloperGuide.adoc 
1.4.3 Setting up CI:
UsingTravis.adoc (Did not continue from "Enabling auto-publishing of documentation" part)
UsingAppVeyor.adoc
